### PR TITLE
Update Validation.js

### DIFF
--- a/Resources/Public/JavaScripts/Validation.js
+++ b/Resources/Public/JavaScripts/Validation.js
@@ -117,9 +117,6 @@ jQuery.fn.femanagerValidation = function() {
 			type: 'POST',
 			cache: false,
 			success: function(data) { // return values
-				if (countForSubmit) {
-					requestCallback.addCallbackToQueue(true);
-				}
 				if (data) {
 					try {
 						var json = $.parseJSON(data);
@@ -132,6 +129,9 @@ jQuery.fn.femanagerValidation = function() {
 						element.before(data)
 					}
 
+				}
+				if (countForSubmit) {
+					requestCallback.addCallbackToQueue(true);
 				}
 			},
 			error: function() {


### PR DESCRIPTION
Now it's possible to validate checkboxes, because the callback is added after error-validation.
This is necessary so submitForm(element) can find errors in HTML
if (element.find('.error').length == 0)