### PR TITLE
TemplateUtility add the default Template from femanger in getTemplate…

### DIFF
--- a/Classes/Utility/TemplateUtility.php
+++ b/Classes/Utility/TemplateUtility.php
@@ -80,7 +80,7 @@ class TemplateUtility extends AbstractUtility
             }
         }
         if ($returnAllPaths || empty($templatePaths)) {
-            $templatePaths[] = 'EXT:femanager/Resources/Private/' . ucfirst($part) . 's/';
+            array_unshift($templatePaths, 'EXT:femanager/Resources/Private/' . ucfirst($part) . 's/');
         }
         $templatePaths = array_unique($templatePaths);
         $absolutePaths = [];


### PR DESCRIPTION
We used array_unshift() instead of $templatePaths[] in getTemplateFolders to make it possible to overwrite the templatePaths from another Extension. After this change the Method getTemplatePath() returns the last configured Template Path.